### PR TITLE
Chore: prettier formatting

### DIFF
--- a/src/components/errors/server-component-error-handler.tsx
+++ b/src/components/errors/server-component-error-handler.tsx
@@ -7,9 +7,7 @@ import {useTranslations} from "@/i18n/provider";
 
 type Props = {
   state:
-    | {success?: boolean | null; errors?: ValidationErrorMap}
-    | null
-    | undefined;
+    {success?: boolean | null; errors?: ValidationErrorMap} | null | undefined;
 };
 
 function ServerComponentErrorHandler({state}: Props) {

--- a/src/dal/public/articles.ts
+++ b/src/dal/public/articles.ts
@@ -18,7 +18,9 @@ export async function fetchArticles(config?: AxiosRequestConfig) {
 export const fetchArticleByCorrelationUUID = cache(
   async (correlationUUID: string, languageCode?: string) => {
     const response = await publicDalDriver.get(`articles/${correlationUUID}`, {
-      headers: languageCode ? {[LANGUAGE_CODE_HEADER]: languageCode} : undefined,
+      headers: languageCode
+        ? {[LANGUAGE_CODE_HEADER]: languageCode}
+        : undefined,
       validateStatus: (status) => status < 500,
     });
     if (response.status === 404) {

--- a/src/features/auth/components/reset-password-form.tsx
+++ b/src/features/auth/components/reset-password-form.tsx
@@ -72,7 +72,9 @@ export function ResetPasswordForm({token}: Props) {
               name="confirm_password"
               mt={"sm"}
               value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.currentTarget.value)}
+              onChange={(event) =>
+                setConfirmPassword(event.currentTarget.value)
+              }
               error={state?.errors?.confirm_password ?? ""}
               disabled={state?.success}
               required

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -9,7 +9,10 @@ import fa from "./dictionaries/fa.json";
 type Dictionary = {config: {direction: Direction}} & Record<string, unknown>;
 type Messages = Omit<Dictionary, "config">;
 
-function adapt(dictionary: Dictionary): {direction: Direction; messages: Messages} {
+function adapt(dictionary: Dictionary): {
+  direction: Direction;
+  messages: Messages;
+} {
   const {config, ...messages} = dictionary;
   return {direction: config.direction, messages};
 }


### PR DESCRIPTION
Four files had drifted from prettier's output on `main`. This reformats them; `prettier . --check` passes on the whole repo afterwards.

- `src/components/errors/server-component-error-handler.tsx`
- `src/dal/public/articles.ts`
- `src/features/auth/components/reset-password-form.tsx`
- `src/i18n/translations.ts`

Whitespace only — no behaviour change. Split out of the same working branch as the contact-us, notes and block-users PRs so those diffs stay about their features. Verified with `tsc --noEmit` and `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)